### PR TITLE
Dynamic Forms Layout without button layout changes

### DIFF
--- a/.forceignore
+++ b/.forceignore
@@ -19,3 +19,6 @@ package.xml
 **/Contact/**
 
 **/unpackaged/**
+**/tsconfig.json
+
+**/*.ts

--- a/force-app/main/default/lwc/indicatorBundle/indicatorBundle.html
+++ b/force-app/main/default/lwc/indicatorBundle/indicatorBundle.html
@@ -24,18 +24,7 @@
                         onclick={refreshCmdt}
                     ></lightning-button-icon>
                 </template>
-                <template lwc:if={isDynamicForms}>
-                    <template lwc:if={showTitle}>
-                        <div>
-                        <div class={sectionHeaderClass}>
-                                <h3 slot="title" class="label slds-section__title slds-truncate slds-p-top_xx-small slds-p-bottom_xx-small slds-theme_shade">
-                                <span class="slds-var-m-left_medium" title="Section Title">{card.title}</span>
-                                </h3>
-                            </div>
-                        </div>
-                    </template>
-                </template>
-                <template lwc:else>
+                <template lwc:if={isStandardUsage}>
                     <template lwc:if={hasHeader} class="cardIcon">
                         <template lwc:if={showTitle}>
                             <h3 slot="title">
@@ -51,26 +40,45 @@
                         </template>
                     </template>
                 </template>
-                <template lwc:if={showDescription}>
-                    <p class="slds-var-p-horizontal_medium slds-var-p-bottom_small">{card.body}</p>
-                </template>
-                <!-- TODO: Do we put this in a Layout which would be responsive to the container, this could allow for empty slots too -->
-                <div class="slds-var-m-left_medium slds-clearfix">
-                    <template if:true={results}>
-                        <template for:each={results} for:item="fld">
-                            <c-indicator-bundle-item if:true={fld.fShowAvatar} key={fld.fName}
-                                ind-text={fld.fTextShown}
-                                ind-size={indsSize}
-                                ind-shape={indsShape} 
-                                ind-hover-text={fld.fHoverValue}
-                                ind-icon={fld.fIconName}
-                                ind-image={fld.fImageURL}
-                                ind-background-color={fld.fIconBackground}
-                                ind-foreground-color={fld.fIconForeground}
-                                >
-                            </c-indicator-bundle-item>
+                <template lwc:else>
+                    <div class="slds-card__body slds-card__body_inner"> 
+                        <template lwc:if={showTitle}>
+                            <div class="section-layout-container slds-section slds-is-open slds-button slds-section__title-action slds-theme_shade">
+                                <h3 slot="title" class="slds-truncate slds-p-around_xx-small">
+                                <span class="slds-text-heading_small" title="Section Title">{card.title}</span>
+                                </h3>
+                            </div>
                         </template>
-                    </template>
+                    </div>
+                </template>
+                <div class={sectionBodyClass}>
+                    <div class="slds-col slds-grid slds-grid_vertical">                 
+                        <div class="slds-col">
+                            <template lwc:if={showDescription}>
+                                <p class="slds-var-p-left_medium slds-var-p-right_x-small slds-var-p-bottom_small">{card.body}</p>
+                            </template>
+                        </div>   
+                        <div class="slds-col">
+                        <!-- TODO: Do we put this in a Layout which would be responsive to the container, this could allow for empty slots too -->
+                            <div class="slds-var-p-left_medium slds-clearfix">
+                                <template if:true={results}>
+                                    <template for:each={results} for:item="fld">
+                                        <c-indicator-bundle-item if:true={fld.fShowAvatar} key={fld.fName}
+                                            ind-text={fld.fTextShown}
+                                            ind-size={indsSize}
+                                            ind-shape={indsShape} 
+                                            ind-hover-text={fld.fHoverValue}
+                                            ind-icon={fld.fIconName}
+                                            ind-image={fld.fImageURL}
+                                            ind-background-color={fld.fIconBackground}
+                                            ind-foreground-color={fld.fIconForeground}
+                                            >
+                                        </c-indicator-bundle-item>
+                                    </template>
+                                </template>
+                            </div>
+                        </div>
+                    </div>
                 </div>
             </lightning-card>
         </template>

--- a/force-app/main/default/lwc/indicatorBundle/indicatorBundle.html
+++ b/force-app/main/default/lwc/indicatorBundle/indicatorBundle.html
@@ -24,25 +24,38 @@
                         onclick={refreshCmdt}
                     ></lightning-button-icon>
                 </template>
-                <template lwc:if={hasHeader} class="cardIcon">
+                <template lwc:if={isDynamicForms}>
                     <template lwc:if={showTitle}>
-                        <h3 slot="title">
-                            <lightning-icon 
-                                lwc:if={card.icon}
-                                icon-name={card.icon} 
-                                size="small"
-                                class={card.iconClass}
-                            >
-                            </lightning-icon>
-                            {card.title}
-                        </h3>
-                    </template>
-                    <template lwc:if={showDescription}>
-                        <p class="slds-var-p-horizontal_medium slds-var-p-bottom_small">{card.body}</p>
+                        <div>
+                        <div class={sectionHeaderClass}>
+                                <h3 slot="title" class="label slds-section__title slds-truncate slds-p-top_xx-small slds-p-bottom_xx-small slds-theme_shade">
+                                <span class="slds-var-m-left_medium" title="Section Title">{card.title}</span>
+                                </h3>
+                            </div>
+                        </div>
                     </template>
                 </template>
+                <template lwc:else>
+                    <template lwc:if={hasHeader} class="cardIcon">
+                        <template lwc:if={showTitle}>
+                            <h3 slot="title">
+                                <lightning-icon 
+                                    lwc:if={card.icon}
+                                    icon-name={card.icon} 
+                                    size="small"
+                                    class={card.iconClass}
+                                >
+                                </lightning-icon>
+                                {card.title}
+                            </h3>
+                        </template>
+                    </template>
+                </template>
+                <template lwc:if={showDescription}>
+                    <p class="slds-var-p-horizontal_medium slds-var-p-bottom_small">{card.body}</p>
+                </template>
                 <!-- TODO: Do we put this in a Layout which would be responsive to the container, this could allow for empty slots too -->
-                <div class="slds-var-m-left_medium">
+                <div class="slds-var-m-left_medium slds-clearfix">
                     <template if:true={results}>
                         <template for:each={results} for:item="fld">
                             <c-indicator-bundle-item if:true={fld.fShowAvatar} key={fld.fName}

--- a/force-app/main/default/lwc/indicatorBundle/indicatorBundle.html
+++ b/force-app/main/default/lwc/indicatorBundle/indicatorBundle.html
@@ -60,7 +60,7 @@
                         </div>   
                         <div class="slds-col">
                         <!-- TODO: Do we put this in a Layout which would be responsive to the container, this could allow for empty slots too -->
-                            <div class="slds-var-p-left_medium slds-clearfix">
+                            <div class="slds-var-m-left_medium slds-clearfix">
                                 <template if:true={results}>
                                     <template for:each={results} for:item="fld">
                                         <c-indicator-bundle-item if:true={fld.fShowAvatar} key={fld.fName}

--- a/force-app/main/default/lwc/indicatorBundle/indicatorBundle.js
+++ b/force-app/main/default/lwc/indicatorBundle/indicatorBundle.js
@@ -118,11 +118,11 @@ export default class IndicatorBundle extends LightningElement {
                         this.card.iconClass = 'slds-var-m-right_x-small ';
                     }
                     
-                    if(this.flexipageRegionWidth == 'SMALL'){
-                        this.sectionBodyClass = 'slds-grid grid-wrap slds-card__body';
-                    } else {
-                        this.card.iconClass = 'slds-media__figure slds-var-m-right_xx-small';
+                    if(this.isStandardUsage != true){
                         this.sectionBodyClass = 'slds-grid grid-wrap slds-card__body slds-card__body_inner';
+                    } else {
+                        this.card.iconClass = 'slds-media__figure slds-var-m-right_x-small';
+                        this.sectionBodyClass = 'slds-grid grid-wrap slds-card__body';
                     }
 
                     // console.log('Card Data');

--- a/force-app/main/default/lwc/indicatorBundle/indicatorBundle.js
+++ b/force-app/main/default/lwc/indicatorBundle/indicatorBundle.js
@@ -14,7 +14,7 @@ export default class IndicatorBundle extends LightningElement {
     @api flexipageRegionWidth;  // Width of the container on record page
     @api showDescription;
     @api showTitle;
-    @api pageUsage = 'standard';
+    @api titleStyle = 'Lightning Card';
     @api indsSize = 'large';
     @api indsShape = 'base';
     @api showRefresh = false;
@@ -56,6 +56,10 @@ export default class IndicatorBundle extends LightningElement {
         if(this.bundle){
             this.initCSSVariables();
         }
+    }
+
+    get isStandardUsage(){
+        return this.titleStyle == 'Lightning Card';
     }
 
     initCSSVariables() {
@@ -107,21 +111,18 @@ export default class IndicatorBundle extends LightningElement {
                     if( this.showTitle || this.showDescription ){
                         this.hasHeader = true;
                     }
-                    
-                    if( this.pageUsage == 'dynamic'){
-                        this.isDynamicForms = true;
-                    }
 
                     if(this.bundle.CardIconBackground || this.bundle.CardIconForeground ){
                         this.card.iconClass = 'cardIcon slds-var-m-right_x-small ';
                     } else {
                         this.card.iconClass = 'slds-var-m-right_x-small ';
                     }
-
+                    
                     if(this.flexipageRegionWidth == 'SMALL'){
-                        this.sectionHeaderClass = 'slds-section slds-is-open slds-var-p-horizontal_medium';
+                        this.sectionBodyClass = 'slds-grid grid-wrap slds-card__body';
                     } else {
-                        this.sectionHeaderClass = 'slds-section slds-is-open';
+                        this.card.iconClass = 'slds-media__figure slds-var-m-right_xx-small';
+                        this.sectionBodyClass = 'slds-grid grid-wrap slds-card__body slds-card__body_inner';
                     }
 
                     // console.log('Card Data');

--- a/force-app/main/default/lwc/indicatorBundle/indicatorBundle.js
+++ b/force-app/main/default/lwc/indicatorBundle/indicatorBundle.js
@@ -14,6 +14,7 @@ export default class IndicatorBundle extends LightningElement {
     @api flexipageRegionWidth;  // Width of the container on record page
     @api showDescription;
     @api showTitle;
+    @api pageUsage = 'standard';
     @api indsSize = 'large';
     @api indsShape = 'base';
     @api showRefresh = false;
@@ -106,11 +107,21 @@ export default class IndicatorBundle extends LightningElement {
                     if( this.showTitle || this.showDescription ){
                         this.hasHeader = true;
                     }
+                    
+                    if( this.pageUsage == 'dynamic'){
+                        this.isDynamicForms = true;
+                    }
 
                     if(this.bundle.CardIconBackground || this.bundle.CardIconForeground ){
-                        this.card.iconClass = 'cardIcon slds-var-m-right_xx-small ';
+                        this.card.iconClass = 'cardIcon slds-var-m-right_x-small ';
                     } else {
-                        this.card.iconClass = 'slds-var-m-right_xx-small ';
+                        this.card.iconClass = 'slds-var-m-right_x-small ';
+                    }
+
+                    if(this.flexipageRegionWidth == 'SMALL'){
+                        this.sectionHeaderClass = 'slds-section slds-is-open slds-var-p-horizontal_medium';
+                    } else {
+                        this.sectionHeaderClass = 'slds-section slds-is-open';
                     }
 
                     // console.log('Card Data');

--- a/force-app/main/default/lwc/indicatorBundle/indicatorBundle.js-meta.xml
+++ b/force-app/main/default/lwc/indicatorBundle/indicatorBundle.js-meta.xml
@@ -10,6 +10,7 @@
     <targetConfigs>
         <targetConfig targets="lightning__RecordPage">
             <property name="bundleName" type="String" label="Indicator Bundle" datasource="apex://IndicatorListBundleSelector" description="Choose the Indicator Bundle."/>
+            <property name="pageUsage" type="String" label="Page Usage" placeholder="standard" datasource="standard,dynamic" description="Choose the Page Usage - Standard Lightning Page, or styled to match Dynamic Forms"/>
             <property name="showTitle" type="Boolean" default="true" label="Display Title" description="Display the Indicator's Title on the component."/>
             <property name="showDescription" type="Boolean" default="true" label="Display Description" description="Display the Indicator's Description on the component."/>
             <property name="indsSize" type="String" label="Indicator Size" placeholder="large" datasource="large,medium" description="Choose the Indicator Size."/>

--- a/force-app/main/default/lwc/indicatorBundle/indicatorBundle.js-meta.xml
+++ b/force-app/main/default/lwc/indicatorBundle/indicatorBundle.js-meta.xml
@@ -10,7 +10,7 @@
     <targetConfigs>
         <targetConfig targets="lightning__RecordPage">
             <property name="bundleName" type="String" label="Indicator Bundle" datasource="apex://IndicatorListBundleSelector" description="Choose the Indicator Bundle."/>
-            <property name="pageUsage" type="String" label="Page Usage" placeholder="standard" datasource="standard,dynamic" description="Choose the Page Usage - Standard Lightning Page, or styled to match Dynamic Forms"/>
+            <property name="titleStyle" type="String" label="Title Style" placeholder="Lightning Card" datasource="Lightning Card,Dynamic Forms" description="Choose the Title Style - Standard Lightning Card, or title Style to match Dynamic Forms"/>
             <property name="showTitle" type="Boolean" default="true" label="Display Title" description="Display the Indicator's Title on the component."/>
             <property name="showDescription" type="Boolean" default="true" label="Display Description" description="Display the Indicator's Description on the component."/>
             <property name="indsSize" type="String" label="Indicator Size" placeholder="large" datasource="large,medium" description="Choose the Indicator Size."/>

--- a/force-app/main/default/lwc/indicatorBundle/indicatorBundle.js-meta.xml
+++ b/force-app/main/default/lwc/indicatorBundle/indicatorBundle.js-meta.xml
@@ -10,7 +10,7 @@
     <targetConfigs>
         <targetConfig targets="lightning__RecordPage">
             <property name="bundleName" type="String" label="Indicator Bundle" datasource="apex://IndicatorListBundleSelector" description="Choose the Indicator Bundle."/>
-            <property name="titleStyle" type="String" label="Title Style" placeholder="Lightning Card" datasource="Lightning Card,Dynamic Forms" description="Choose the Title Style - Standard Lightning Card, or title Style to match Dynamic Forms"/>
+            <property name="titleStyle" type="String" label="Title Style" placeholder="Lightning Card" datasource="Lightning Card,Dynamic Forms" description="Choose the Title Style: Standard Lightning Card or a style to match Dynamic Forms"/>
             <property name="showTitle" type="Boolean" default="true" label="Display Title" description="Display the Indicator's Title on the component."/>
             <property name="showDescription" type="Boolean" default="true" label="Display Description" description="Display the Indicator's Description on the component."/>
             <property name="indsSize" type="String" label="Indicator Size" placeholder="large" datasource="large,medium" description="Choose the Indicator Size."/>

--- a/force-app/main/default/lwc/indicatorBundleItem/indicatorBundleItem.html
+++ b/force-app/main/default/lwc/indicatorBundleItem/indicatorBundleItem.html
@@ -1,13 +1,15 @@
 <template>
-    <template if:false={record}>
-        <lightning-avatar 
-            size={indSize}
-            variant={indShape}
-            initials={indText}
-            src={indImage} 
-            fallback-icon-name={indIcon}
-            alternative-text={indHoverText} 
-            class={indClass}>
-        </lightning-avatar>
-    </template>
+    <div class="slds-var-m-bottom_x-small slds-float_left">
+        <template if:false={record}>
+            <lightning-avatar 
+                size={indSize}
+                variant={indShape}
+                initials={indText}
+                src={indImage} 
+                fallback-icon-name={indIcon}
+                alternative-text={indHoverText} 
+                class={indClass}>
+            </lightning-avatar>
+        </template>
+    </div>
 </template>

--- a/force-app/main/default/lwc/indicatorBundleItem/indicatorBundleItem.html
+++ b/force-app/main/default/lwc/indicatorBundleItem/indicatorBundleItem.html
@@ -1,15 +1,13 @@
 <template>
     <div class="slds-var-m-bottom_x-small slds-float_left">
-        <template if:false={record}>
-            <lightning-avatar 
-                size={indSize}
-                variant={indShape}
-                initials={indText}
-                src={indImage} 
-                fallback-icon-name={indIcon}
-                alternative-text={indHoverText} 
-                class={indClass}>
-            </lightning-avatar>
-        </template>
+        <lightning-avatar 
+            size={indSize}
+            variant={indShape}
+            initials={indText}
+            src={indImage} 
+            fallback-icon-name={indIcon}
+            alternative-text={indHoverText} 
+            class={indClass}>
+        </lightning-avatar>
     </div>
 </template>


### PR DESCRIPTION
# Changes
* A new option in the Property Editor to select the usage of the Bundle on the Page - either Standard Lightning (default) or Dynamic Forms. If Dynamic Forms is chosen it changes the header of the Bundle to a look more in keeping with Dynamic Forms. This allows the Bundle to be displayed in between field sections if that is more useful to display icons near the fields they relate to. 

# Issues Closed
#173 

# Code Notes
* This still has the existing buttons in the slot. It doesn't look the best but #172 will include the better layout of the buttons