### PR TITLE
Permit the use of an Id from a field

### DIFF
--- a/force-app/main/default/lwc/illustration/illustration.html
+++ b/force-app/main/default/lwc/illustration/illustration.html
@@ -6,7 +6,7 @@
     <div class="slds-text-longform">
       <h3 class="slds-text-heading_medium">{heading}</h3>
       <slot name="messageBody">
-        <p class="slds-text-body_regular">{messageBody}</p>
+        <p class="slds-text-body_regular slds-p-around_xx-small">{messageBody}</p>
       </slot>
     </div>
   </div>

--- a/force-app/main/default/lwc/indicatorBundle/indicatorBundle.html
+++ b/force-app/main/default/lwc/indicatorBundle/indicatorBundle.html
@@ -92,6 +92,12 @@
                         </div>
                     </div>
                 </div>
+                <template lwc:if={displayFooter}>
+                    <footer class="slds-card__footer">
+                        <lightning-badge label={mappedField}></lightning-badge>
+                        <lightning-helptext content={targetMessage}></lightning-helptext>
+                    </footer>
+                </template>
             </article>
         </template>
     </template>

--- a/force-app/main/default/lwc/indicatorBundle/indicatorBundle.js-meta.xml
+++ b/force-app/main/default/lwc/indicatorBundle/indicatorBundle.js-meta.xml
@@ -10,12 +10,14 @@
     <targetConfigs>
         <targetConfig targets="lightning__RecordPage">
             <property name="bundleName" type="String" label="Indicator Bundle" datasource="apex://IndicatorListBundleSelector" description="Choose the Indicator Bundle."/>
-            <property name="titleStyle" type="String" label="Title Style" placeholder="Lightning Card" datasource="Lightning Card,Dynamic Forms" description="Choose the Title Style: Standard Lightning Card or a style to match Dynamic Forms"/>
+            <property name="titleStyle" type="String" label="Title Style" placeholder="Lightning Card" datasource="Lightning Card,Dynamic Forms" description="Choose the Title Style: Standard Lightning Card or a style to match Dynamic Forms."/>
             <property name="showTitle" type="Boolean" default="true" label="Display Title" description="Display the Indicator's Title on the component."/>
             <property name="showDescription" type="Boolean" default="true" label="Display Description" description="Display the Indicator's Description on the component."/>
             <property name="indsSize" type="String" label="Indicator Size" placeholder="large" datasource="large,medium" description="Choose the Indicator Size."/>
             <property name="indsShape" type="String" label="Indicator Shape" placeholder="base" datasource="base,circle" description="Choose the Indicator Shape."/>
             <property name="showRefresh" type="Boolean" label="Show refresh button" description="Enable an admin button to refresh the values."/>
+            <property name="mappedField" type="String" label="(Optional) Mapped Id Field" description="(Optional) Instead of using the current Record Id, provide the API Name of a field (Case Sensitive) on this object which holds a Record Id or Relationship Id to use that value." placeholder="Example: Source_Id__c, ParentId, or AccountId" />
+            <property name="showFooter" type="Boolean" label="Show footer when using Mapped Id Field" description="Enable a footer to show what mapped field is being used."/>
             <supportedFormFactors>
                 <supportedFormFactor type="Large" />
                 <supportedFormFactor type="Small" />


### PR DESCRIPTION

# Critical Changes

# Changes

Added new property attribute to use a field's ID value instead of the record id.
Also added a property attribute to enable/disable a footer informing the user about the mapped field use.

# Issues Closed

# Known Issue

Mapped fields are case-sensitive for their API names.  It appears that when trying to use `id` as the mapped API name, it will not generate an error illustration nor will it display any data.  Other combinations were tested and appeared to be cache issues, but `id` has consistently resulted in this scenario.
