### PR TITLE
Merge main into feature/staging-claude (resolves conflicts from #222)

### DIFF
--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -115,26 +115,33 @@ flows:
   config_dev:
     steps:
       3:
-        task: generate_accounts_and_contacts
+        task: assign_permission_sets
+        options:
+          api_names: Indicators_Setup_Access
       4:
-        flow: sample_inds
+        task: generate_accounts_and_contacts
       5:
+        flow: sample_inds
+      6:
         task: deploy_sample_indicators_objects
+
   
   config_demo:
     steps:
       1:
         flow: install_prod
       2:
-        flow: sample_inds
+        task: assign_permission_sets
+        options:
+          api_names: Indicators_Setup_Access
       3:
-        task: deploy_sample_indicators_objects
-      4:
-        task: deploy_sample_indicators_layouts
-      5:
-        task: deploy_training_indicators
-      6:
         task: generate_accounts_and_contacts
+      4:
+        flow: sample_inds
+      5:
+        task: deploy_sample_indicators_objects
+      6:
+        task: deploy_training_indicators
 
 plans:
   install:

--- a/force-app/main/default/lwc/indicatorBundle/indicatorBundle.html
+++ b/force-app/main/default/lwc/indicatorBundle/indicatorBundle.html
@@ -104,16 +104,18 @@
     <template if:true={errorOccurred}>
         <template lwc:if={isManageEnabled}>
             <lightning-card variant="base" title="Error" icon-name="utility:error">
-                <p>{errorMessage}</p>
-                <template if:true={showIllustration}>
-                    <c-illustration
-                        heading =  {illustration.heading}
-                        message-body = {illustration.messageBody}
-                        image-name = {illustration.imageName}
-                        image-size = {flexipageRegionWidth}
-                        class="slds-illustration slds-illustration_small"
-                    ></c-illustration>
-                </template>
+                <div class="slds-card__body slds-card__body_inner">
+                    {errorMessage}
+                    <template if:true={showIllustration}>
+                        <c-illustration
+                            heading =  {illustration.heading}
+                            message-body = {illustration.messageBody}
+                            image-name = {illustration.imageName}
+                            image-size = {flexipageRegionWidth}
+                            class="slds-illustration slds-illustration_small"
+                        ></c-illustration>
+                    </template>
+                </div>
             </lightning-card>
         </template>
     </template>

--- a/force-app/main/default/lwc/indicatorBundle/indicatorBundle.js
+++ b/force-app/main/default/lwc/indicatorBundle/indicatorBundle.js
@@ -3,6 +3,7 @@ import { getRecord, getFieldValue } from 'lightning/uiRecordApi';
 import { getObjectInfo } from 'lightning/uiObjectInfoApi';
 import { refreshApex } from '@salesforce/apex';
 import KeyModal from 'c/indicatorBundleKey';
+import { reduceErrors } from 'c/ldsUtils';
 
 import hasManagePermission from '@salesforce/customPermission/Manage_Indicator_Key';
 import getIndicatorConfig from '@salesforce/apex/IndicatorController.getIndicatorBundle';
@@ -89,8 +90,8 @@ export default class IndicatorBundle extends LightningElement {
                     imageName: 'custom:setup'
                 };
             } else {
-                this.targetMessage = 'This Indicator Bundle displays indicators based on the record id (' + data.fields[this.mappedField].value + ') in the mapped field \"' + this.mappedField + '\" from the ' + data.apiName + ' object.';
                 this.targetIdValue = getFieldValue(data, this.targetIdField);
+                this.targetMessage = 'This Indicator Bundle displays indicators based on the record id (' + this.targetIdValue + ') in the mapped field \"' + this.mappedField + '\" from the ' + this.objectApiName + ' object.';
                 this.showIllustration=false;
                 this.illustration = {};
             }
@@ -208,7 +209,7 @@ export default class IndicatorBundle extends LightningElement {
             this.bundle = undefined;
             this.bundleActive = false;
             this.errorOccurred = true;
-            this.errorMessage = JSON.stringify(error);
+            this.errorMessage = reduceErrors(error).join(', '); //JSON.stringify(error);
         }
     }
 
@@ -420,7 +421,7 @@ export default class IndicatorBundle extends LightningElement {
             // console.log('FieldValue => ', JSON.stringify(this.results));   // Retain for debug purposes
         } else if (error) {
             console.log('Error!');
-            this.errorMessage = JSON.stringify(error);
+            this.errorMessage = reduceErrors(error).join(', ');//JSON.stringify(error);
             this.errorOccurred = true;
         }
 

--- a/force-app/main/default/lwc/ldsUtils/ldsUtils.js
+++ b/force-app/main/default/lwc/ldsUtils/ldsUtils.js
@@ -1,0 +1,81 @@
+/**
+ * Reduces one or more LDS errors into a string[] of error messages.
+ * @param {FetchResponse|FetchResponse[]} errors
+ * @return {String[]} Error messages
+ */
+export function reduceErrors(errors) {
+    if (!Array.isArray(errors)) {
+        errors = [errors];
+    }
+
+    return (
+        errors
+            // Remove null/undefined items
+            .filter((error) => !!error)
+            // Extract an error message
+            .map((error) => {
+                // UI API read errors
+                if (Array.isArray(error.body)) {
+                    return error.body.map((e) => e.message);
+                }
+                // Page level errors
+                else if (
+                    error?.body?.pageErrors &&
+                    error.body.pageErrors.length > 0
+                ) {
+                    return error.body.pageErrors.map((e) => e.message);
+                }
+                // Field level errors
+                else if (
+                    error?.body?.fieldErrors &&
+                    Object.keys(error.body.fieldErrors).length > 0
+                ) {
+                    const fieldErrors = [];
+                    Object.values(error.body.fieldErrors).forEach(
+                        (errorArray) => {
+                            fieldErrors.push(
+                                ...errorArray.map((e) => e.message)
+                            );
+                        }
+                    );
+                    return fieldErrors;
+                }
+                // UI API DML page level errors
+                else if (
+                    error?.body?.output?.errors &&
+                    error.body.output.errors.length > 0
+                ) {
+                    return error.body.output.errors.map((e) => e.message);
+                }
+                // UI API DML field level errors
+                else if (
+                    error?.body?.output?.fieldErrors &&
+                    Object.keys(error.body.output.fieldErrors).length > 0
+                ) {
+                    const fieldErrors = [];
+                    Object.values(error.body.output.fieldErrors).forEach(
+                        (errorArray) => {
+                            fieldErrors.push(
+                                ...errorArray.map((e) => e.message)
+                            );
+                        }
+                    );
+                    return fieldErrors;
+                }
+                // UI API DML, Apex and network errors
+                else if (error.body && typeof error.body.message === 'string') {
+                    return error.body.message;
+                }
+                // JS errors
+                else if (typeof error.message === 'string') {
+                    return error.message;
+                }
+                // Unknown error shape so try HTTP status text
+                return error.statusText;
+            })
+            // Flatten
+            .reduce((prev, curr) => prev.concat(curr), [])
+            // Remove empty strings
+            .filter((message) => !!message)
+    );
+}

--- a/force-app/main/default/lwc/ldsUtils/ldsUtils.js-meta.xml
+++ b/force-app/main/default/lwc/ldsUtils/ldsUtils.js-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>65.0</apiVersion>
+    <isExposed>false</isExposed>
+</LightningComponentBundle>

--- a/force-app/main/default/objects/Indicator_Item_Extension__mdt/fields/Priority__c.field-meta.xml
+++ b/force-app/main/default/objects/Indicator_Item_Extension__mdt/fields/Priority__c.field-meta.xml
@@ -3,7 +3,7 @@
     <fullName>Priority__c</fullName>
     <externalId>false</externalId>
     <fieldManageability>SubscriberControlled</fieldManageability>
-    <inlineHelpText>Priority of this rule.  If an field&apos;s value first multiple extension rules, the lowest priority will be used.</inlineHelpText>
+    <inlineHelpText>Priority of this rule.  If multiple extension rules apply and Indicator Item's "Display Multiple" is set to false, then the extension with the lowest priority will be used.</inlineHelpText>
     <label>Priority</label>
     <precision>4</precision>
     <required>false</required>


### PR DESCRIPTION
Manually resolves the merge conflicts that PR #222 (bot-generated, head=main) hit.

Branched from `feature/staging-claude`, merged `origin/main` in, resolved:
- `indicatorBundle.js` — combined both branches' new imports (`FlowModal`/`applyColorVars` from staging-claude, `reduceErrors` from main)
- `Priority__c.field-meta.xml` — combined both help-text edits into one sentence

Once merged, closes #222 (its diff should become empty).